### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ## [1.1.0] - 2019-09-29
 
 - Added support to `linux/arm` and `linux/arm64` targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Update docker image to golang-cross:1.12.12 
+
 ## [1.1.0] - 2019-09-29
 
 - Added support to `linux/arm` and `linux/arm64` targets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Fix UID is already in use [#12](https://github.com/lucor/fyne-cross/issues/12)
-- Update docker image to golang-cross:1.12.12 
+- Update docker image to golang-cross:1.12.12
+- Add `--no-strip` flag. Since 1.1.0 by default the -w and -s flags are passed to the linker to strip binaries size omitting the symbol table, debug information and the DWARF symbol table. Specify this flag to add debug info. [#13](https://github.com/lucor/fyne-cross/issues/13)
 
 ## [1.1.0] - 2019-09-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [1.2.0] - 2019-10-26
 
 - Fix UID is already in use [#12](https://github.com/lucor/fyne-cross/issues/12)
 - Update docker image to golang-cross:1.12.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix UID is already in use [#12](https://github.com/lucor/fyne-cross/issues/12)
 - Update docker image to golang-cross:1.12.12 
 
 ## [1.1.0] - 2019-09-29

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockercore/golang-cross:1.12.10
+FROM dockercore/golang-cross:1.12.12
 
 RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \

--- a/build.go
+++ b/build.go
@@ -13,7 +13,7 @@ import (
 )
 
 const dockerImage = "lucor/fyne-cross:develop"
-const version = "1.1.0"
+const version = "dev"
 
 // targetWithBuildOpts represents the list of supported GOOS/GOARCH with the relative
 // options to build

--- a/build.go
+++ b/build.go
@@ -59,6 +59,8 @@ var (
 	ldflags string
 	// printVersion if true will print the fyne-cross version
 	printVersion bool
+	// noStripDebug if true will not strip debug information from binaries
+	noStripDebug bool
 )
 
 // builder is the command implementing the fyne app command interface
@@ -71,7 +73,8 @@ func (b *builder) addFlags() {
 	flag.StringVar(&pkgRootDir, "dir", "", "The package root directory. Default current dir")
 	flag.StringVar(&goPath, "gopath", "", "The local GOPATH to mount into container, used to share/cache sources and dependencies. Default to system cache directory (i.e. $HOME/.cache/fyne-cross)")
 	flag.BoolVar(&verbose, "v", false, "Enable verbosity flag for go commands. Default to false")
-	flag.StringVar(&ldflags, "ldflags", "", "flags to pass to the external linker")
+	flag.StringVar(&ldflags, "ldflags", "", "Flags to pass to the external linker")
+	flag.BoolVar(&noStripDebug, "no-strip", false, "If set will not strip debug information from binaries")
 	flag.BoolVar(&printVersion, "version", false, "Print fyne-cross version")
 }
 
@@ -149,13 +152,14 @@ func (b *builder) run(args []string) {
 	}
 
 	db := dockerBuilder{
-		pkg:     pkg,
-		workDir: pkgRootDir,
-		goPath:  goPath,
-		targets: targets,
-		output:  output,
-		verbose: verbose,
-		ldflags: ldflags,
+		pkg:        pkg,
+		workDir:    pkgRootDir,
+		goPath:     goPath,
+		targets:    targets,
+		output:     output,
+		verbose:    verbose,
+		ldflags:    ldflags,
+		stripDebug: !noStripDebug,
 	}
 
 	err = db.checkRequirements()
@@ -186,13 +190,14 @@ func (b *builder) run(args []string) {
 
 // dockerBuilder represents the docker builder
 type dockerBuilder struct {
-	targets []string
-	output  string
-	pkg     string
-	workDir string
-	goPath  string
-	verbose bool
-	ldflags string
+	targets    []string
+	output     string
+	pkg        string
+	workDir    string
+	goPath     string
+	verbose    bool
+	ldflags    string
+	stripDebug bool
 }
 
 // checkRequirements checks if all the build requirements are satisfied
@@ -332,10 +337,13 @@ func (d *dockerBuilder) goBuildArgs(target string) ([]string, error) {
 	args = append(args, "go", "build")
 
 	// Start adding ldflags
-	ldflags := []string{
-		"-w",
-		"-s",
+	ldflags := []string{}
+
+	// Strip debug information
+	if d.stripDebug {
+		ldflags = append(ldflags, "-w", "-s")
 	}
+
 	// add defaults
 	if ldflagsDefault, ok := targetLdflags[target]; ok {
 		ldflags = append(ldflags, ldflagsDefault)

--- a/build.go
+++ b/build.go
@@ -13,7 +13,7 @@ import (
 )
 
 const dockerImage = "lucor/fyne-cross:develop"
-const version = "dev"
+const version = "1.2.0"
 
 // targetWithBuildOpts represents the list of supported GOOS/GOARCH with the relative
 // options to build

--- a/build_test.go
+++ b/build_test.go
@@ -282,12 +282,13 @@ func Test_dockerBuilder_goGetArgs(t *testing.T) {
 }
 func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 	type fields struct {
-		targets []string
-		output  string
-		pkg     string
-		workDir string
-		verbose bool
-		ldflags string
+		targets    []string
+		output     string
+		pkg        string
+		workDir    string
+		verbose    bool
+		ldflags    string
+		stripDebug bool
 	}
 	type args struct {
 		target string
@@ -303,10 +304,11 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 		{
 			name: "verbosity enabled, linux",
 			fields: fields{
-				verbose: true,
-				pkg:     "fyne-io/fyne-example",
-				workDir: "/code/test",
-				output:  "test",
+				verbose:    true,
+				pkg:        "fyne-io/fyne-example",
+				workDir:    "/code/test",
+				output:     "test",
+				stripDebug: true,
 			},
 			args: args{
 				target: "linux/amd64",
@@ -340,7 +342,7 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 				"-e", "GOOS=windows", "-e", "GOARCH=amd64", "-e", "CC=x86_64-w64-mingw32-gcc",
 				dockerImage,
 				"go", "build",
-				"-ldflags", "'-w -s -H windowsgui -X main.version=1.0.0'",
+				"-ldflags", "'-H windowsgui -X main.version=1.0.0'",
 				"-o", "build/test-windows-amd64.exe",
 				"-a",
 				"fyne-io/fyne-example",
@@ -359,7 +361,6 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 				"-e", "GOOS=darwin", "-e", "GOARCH=amd64", "-e", "CC=o32-clang",
 				dockerImage,
 				"go", "build",
-				"-ldflags", "'-w -s'",
 				"-o", "build/fyne-example-darwin-amd64",
 				"-a",
 				"fyne-io/fyne-example",
@@ -368,11 +369,12 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 		{
 			name: "ldflags, linux",
 			fields: fields{
-				verbose: true,
-				pkg:     "fyne-io/fyne-example",
-				workDir: "/code/test",
-				output:  "test",
-				ldflags: "-X main.version=1.0.0",
+				verbose:    true,
+				pkg:        "fyne-io/fyne-example",
+				workDir:    "/code/test",
+				output:     "test",
+				ldflags:    "-X main.version=1.0.0",
+				stripDebug: true,
 			},
 			args: args{
 				target: "linux/amd64",
@@ -405,7 +407,6 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 				"-e", "GOOS=linux", "-e", "GOARCH=arm", "-e", "CC=arm-linux-gnueabihf-gcc", "-e", "GOARM=7",
 				dockerImage,
 				"go", "build",
-				"-ldflags", "'-w -s'",
 				"-tags", "'gles'",
 				"-o", "build/test-linux-arm",
 				"-a",
@@ -429,7 +430,6 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 				"-e", "GOOS=linux", "-e", "GOARCH=arm64", "-e", "CC=aarch64-linux-gnu-gcc",
 				dockerImage,
 				"go", "build",
-				"-ldflags", "'-w -s'",
 				"-tags", "'gles'",
 				"-o", "build/test-linux-arm64",
 				"-a",
@@ -441,12 +441,13 @@ func Test_dockerBuilder_goBuildArgs(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			d := &dockerBuilder{
-				targets: tt.fields.targets,
-				output:  tt.fields.output,
-				pkg:     tt.fields.pkg,
-				workDir: tt.fields.workDir,
-				verbose: tt.fields.verbose,
-				ldflags: tt.fields.ldflags,
+				targets:    tt.fields.targets,
+				output:     tt.fields.output,
+				pkg:        tt.fields.pkg,
+				workDir:    tt.fields.workDir,
+				verbose:    tt.fields.verbose,
+				ldflags:    tt.fields.ldflags,
+				stripDebug: tt.fields.stripDebug,
 			}
 			got, err := d.goBuildArgs(tt.args.target)
 			if (err != nil) != tt.wantErr {

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-if [ -n "$fyne_uid" ]; then
-    adduser -q --disabled-password --gecos "" --uid $fyne_uid fyne 
+if [ -n "$fyne_uid" -a "$fyne_uid" -gt 0 ]; then
+    id -u $fyne_uid > /dev/null 2>&1 || adduser -q --disabled-password --gecos "" --uid $fyne_uid fyne 
     chown $fyne_uid /go
     eval exec gosu $fyne_uid $@
 fi


### PR DESCRIPTION
- Fix UID is already in use [#12](https://github.com/lucor/fyne-cross/issues/12)
- Update docker image to golang-cross:1.12.12
- Add `--no-strip` flag. Since 1.1.0 by default the -w and -s flags are passed to the linker to strip binaries size omitting the symbol table, debug information and the DWARF symbol table. Specify this flag to add debug info. [#13](https://github.com/lucor/fyne-cross/issues/13)