### PR TITLE
Add support for using a custom docker image

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -7,10 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"os/user"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/lucor/fyne-cross/internal/volume"
@@ -36,9 +33,18 @@ type Builder interface {
 	BuildEnv() []string
 	BuildLdFlags() []string
 	BuildTags() []string
+	DockerImage() string
 	Package(vol *volume.Volume, opts PackageOptions) error
 	Output() string
 	TargetID() string
+}
+
+// Options specifies the options for creating
+// the types that implement the Builder interface
+type Options struct {
+	Arch        string
+	Output      string
+	DockerImage string
 }
 
 // PreBuildOptions holds the options for the pre build step
@@ -64,57 +70,8 @@ type PackageOptions struct {
 	Verbose bool   // Verbose if true, enable verbose mode
 }
 
-// dockerCmd exec a command inside the container for the specified image
-func dockerCmd(image string, vol *volume.Volume, env []string, workDir string, command []string, verbose bool) *exec.Cmd {
-	// define workdir
-	w := vol.WorkDirContainer()
-	if workDir != "" {
-		w = workDir
-	}
-
-	args := []string{
-		"run", "--rm", "-t",
-		"-w", w, // set workdir
-		"-v", fmt.Sprintf("%s:%s", vol.WorkDirHost(), vol.WorkDirContainer()), // mount the working dir
-		"-v", fmt.Sprintf("%s:%s", vol.CacheDirHost(), vol.CacheDirContainer()), // mount the cache dir
-		"-e", "CGO_ENABLED=1", // enable CGO
-		"-e", fmt.Sprintf("GOCACHE=%s", vol.GoCacheDirContainer()), // mount GOCACHE to reuse cache between builds
-	}
-
-	// add custom env variables
-	for _, e := range env {
-		args = append(args, "-e", e)
-	}
-
-	// attempt to set fyne user id as current user id to handle mount permissions
-	// on linux and MacOS
-	if runtime.GOOS != "windows" {
-		u, err := user.Current()
-		if err == nil {
-			args = append(args, "-e", fmt.Sprintf("fyne_uid=%s", u.Uid))
-		}
-	}
-
-	// specify the image to use
-	args = append(args, image)
-
-	// add the command to execute
-	args = append(args, command...)
-
-	// run the command inside the container
-	cmd := exec.Command("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	if verbose {
-		fmt.Println(cmd.String())
-	}
-
-	return cmd
-}
-
 // goModInit ensure a go.mod exists. If not try to generates a temporary one
-func goModInit(vol *volume.Volume, verbose bool) error {
+func goModInit(b Builder, vol *volume.Volume, verbose bool) error {
 	// check if the go.mod exists
 	goModPath := filepath.Join(vol.WorkDirHost(), "go.mod")
 	_, err := os.Stat(goModPath)
@@ -131,7 +88,7 @@ func goModInit(vol *volume.Volume, verbose bool) error {
 
 	// Module does not exists, generate a temporary one
 	command := "go mod init fyne-cross-temp-module"
-	err = dockerCmd(baseDockerImage, vol, []string{}, vol.WorkDirContainer(), []string{command}, verbose).Run()
+	err = runBuilderDockerCmd(b, vol, []string{}, vol.WorkDirContainer(), []string{command}, verbose)
 
 	if err != nil {
 		return fmt.Errorf("Could not generate the temporary go module: %v", err)

--- a/internal/builder/darwin_test.go
+++ b/internal/builder/darwin_test.go
@@ -4,9 +4,8 @@ import "testing"
 
 func TestDarwin_Output(t *testing.T) {
 	type fields struct {
-		os     string
-		arch   string
-		output string
+		os   string
+		opts Options
 	}
 	tests := []struct {
 		name   string
@@ -16,23 +15,27 @@ func TestDarwin_Output(t *testing.T) {
 		{
 			name: "amd64",
 			fields: fields{
-				arch:   "amd64",
-				output: "test",
+				opts: Options{
+					Arch:   "amd64",
+					Output: "test",
+				},
 			},
 			want: "test",
 		},
 		{
 			name: "386",
 			fields: fields{
-				arch:   "386",
-				output: "test",
+				opts: Options{
+					Arch:   "386",
+					Output: "test",
+				},
 			},
 			want: "test",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewDarwin(tt.fields.arch, tt.fields.output)
+			b := NewDarwin(tt.fields.opts)
 			if got := b.Output(); got != tt.want {
 				t.Errorf("Darwin.Output() = %v, want %v", got, tt.want)
 			}

--- a/internal/builder/docker.go
+++ b/internal/builder/docker.go
@@ -18,11 +18,13 @@ type dockerImageProvider interface {
 	DockerImageName() (string, error)
 }
 
-type dockerRemoteImage struct {
+// Docker image referenced by name. Might be local
+// or remote.
+type dockerImageName struct {
 	Name string
 }
 
-func (d *dockerRemoteImage) DockerImageName() (string, error) {
+func (d *dockerImageName) DockerImageName() (string, error) {
 	return d.Name, nil
 }
 
@@ -55,8 +57,8 @@ func newDockerImageProvider(imageName string) dockerImageProvider {
 	if filepath.Base(imageName) == "Dockerfile" && isFile(imageName) {
 		return &dockerFile{Path: imageName}
 	}
-	// Assume it's a remote image name
-	return &dockerRemoteImage{Name: imageName}
+	// Assume it's an image name
+	return &dockerImageName{Name: imageName}
 }
 
 // dockerCmd exec a command inside the container for the specified image

--- a/internal/builder/docker.go
+++ b/internal/builder/docker.go
@@ -1,0 +1,121 @@
+package builder
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"runtime"
+
+	"github.com/lucor/fyne-cross/internal/volume"
+)
+
+type dockerImageProvider interface {
+	DockerImageName() (string, error)
+}
+
+type dockerRemoteImage struct {
+	Name string
+}
+
+func (d *dockerRemoteImage) DockerImageName() (string, error) {
+	return d.Name, nil
+}
+
+type dockerFile struct {
+	Path string
+}
+
+func (d *dockerFile) DockerImageName() (string, error) {
+	// Hash the Dockerfile to produce an image name
+	data, err := ioutil.ReadFile(d.Path)
+	if err != nil {
+		return "", err
+	}
+	h := sha1.Sum(data)
+	image := hex.EncodeToString(h[:])
+	dir := filepath.Dir(d.Path)
+	cmd := exec.Command("docker", "build", dir, "-t", image)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	return image, nil
+}
+
+func isFile(p string) bool {
+	st, err := os.Stat(p)
+	return err == nil && !st.IsDir()
+}
+
+func newDockerImageProvider(imageName string) dockerImageProvider {
+	if filepath.Base(imageName) == "Dockerfile" && isFile(imageName) {
+		return &dockerFile{Path: imageName}
+	}
+	// Assume it's a remote image name
+	return &dockerRemoteImage{Name: imageName}
+}
+
+// dockerCmd exec a command inside the container for the specified image
+func dockerCmd(image string, vol *volume.Volume, env []string, workDir string, command []string, verbose bool) *exec.Cmd {
+	// define workdir
+	w := vol.WorkDirContainer()
+	if workDir != "" {
+		w = workDir
+	}
+
+	args := []string{
+		"run", "--rm", "-t",
+		"-w", w, // set workdir
+		"-v", fmt.Sprintf("%s:%s", vol.WorkDirHost(), vol.WorkDirContainer()), // mount the working dir
+		"-v", fmt.Sprintf("%s:%s", vol.CacheDirHost(), vol.CacheDirContainer()), // mount the cache dir
+		"-e", "CGO_ENABLED=1", // enable CGO
+		"-e", fmt.Sprintf("GOCACHE=%s", vol.GoCacheDirContainer()), // mount GOCACHE to reuse cache between builds
+	}
+
+	// add custom env variables
+	for _, e := range env {
+		args = append(args, "-e", e)
+	}
+
+	// attempt to set fyne user id as current user id to handle mount permissions
+	// on linux and MacOS
+	if runtime.GOOS != "windows" {
+		u, err := user.Current()
+		if err == nil {
+			args = append(args, "-e", fmt.Sprintf("fyne_uid=%s", u.Uid))
+		}
+	}
+
+	// specify the image to use
+	args = append(args, image)
+
+	// add the command to execute
+	args = append(args, command...)
+
+	// run the command inside the container
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if verbose {
+		fmt.Println(cmd.String())
+	}
+
+	return cmd
+}
+
+// runBuilderDockerCmd runs the given command in the docker image returned by the Builder
+func runBuilderDockerCmd(builder Builder, vol *volume.Volume, env []string, workDir string, command []string, verbose bool) error {
+	// retrieve image
+	imageName := builder.DockerImage()
+	provider := newDockerImageProvider(imageName)
+	image, err := provider.DockerImageName()
+	if err != nil {
+		return err
+	}
+	return dockerCmd(image, vol, env, workDir, command, verbose).Run()
+}

--- a/internal/builder/linux_test.go
+++ b/internal/builder/linux_test.go
@@ -4,9 +4,8 @@ import "testing"
 
 func TestLinux_Output(t *testing.T) {
 	type fields struct {
-		os     string
-		arch   string
-		output string
+		os   string
+		opts Options
 	}
 	tests := []struct {
 		name   string
@@ -16,23 +15,27 @@ func TestLinux_Output(t *testing.T) {
 		{
 			name: "amd64",
 			fields: fields{
-				arch:   "amd64",
-				output: "test",
+				opts: Options{
+					Arch:   "amd64",
+					Output: "test",
+				},
 			},
 			want: "test",
 		},
 		{
 			name: "386",
 			fields: fields{
-				arch:   "386",
-				output: "test",
+				opts: Options{
+					Arch:   "386",
+					Output: "test",
+				},
 			},
 			want: "test",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewLinux(tt.fields.arch, tt.fields.output)
+			b := NewLinux(tt.fields.opts)
 			if got := b.Output(); got != tt.want {
 				t.Errorf("Linux.Output() = %v, want %v", got, tt.want)
 			}

--- a/internal/builder/windows_test.go
+++ b/internal/builder/windows_test.go
@@ -4,9 +4,8 @@ import "testing"
 
 func TestWindows_Output(t *testing.T) {
 	type fields struct {
-		os     string
-		arch   string
-		output string
+		os   string
+		opts Options
 	}
 	tests := []struct {
 		name   string
@@ -16,23 +15,27 @@ func TestWindows_Output(t *testing.T) {
 		{
 			name: "amd64",
 			fields: fields{
-				arch:   "amd64",
-				output: "test",
+				opts: Options{
+					Arch:   "amd64",
+					Output: "test",
+				},
 			},
 			want: "test.exe",
 		},
 		{
 			name: "386",
 			fields: fields{
-				arch:   "386",
-				output: "test",
+				opts: Options{
+					Arch:   "386",
+					Output: "test",
+				},
 			},
 			want: "test.exe",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := NewWindows(tt.fields.arch, tt.fields.output)
+			b := NewWindows(tt.fields.opts)
 			if got := b.Output(); got != tt.want {
 				t.Errorf("Windows.Output() = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
Add a -docker-image argument, which can be either an image name
or a Dockerfile. This allows the user to use a custom docker image
which is useful for e.g. compiling the Linux version when it has
additional dependencies.