### PR TITLE
Pass ldflags to each command's context

### DIFF
--- a/internal/command/android.go
+++ b/internal/command/android.go
@@ -151,6 +151,11 @@ func makeAndroidContext(flags *androidFlags) (Context, error) {
 	ctx.OS = androidOS
 	ctx.ID = androidOS
 
+	// set context based on command-line flags
+	if len(flags.Ldflags) > 0 {
+		ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+	}
+
 	if flags.DockerImage == "" {
 		ctx.DockerImage = androidImage
 	}

--- a/internal/command/android.go
+++ b/internal/command/android.go
@@ -152,10 +152,6 @@ func makeAndroidContext(flags *androidFlags) (Context, error) {
 	ctx.ID = androidOS
 
 	// set context based on command-line flags
-	if len(flags.Ldflags) > 0 {
-		ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-	}
-
 	if flags.DockerImage == "" {
 		ctx.DockerImage = androidImage
 	}

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -69,6 +69,7 @@ func makeDefaultContext(flags *CommonFlags) (Context, error) {
 		return Context{}, err
 	}
 
+	// set context based on command-line flags
 	ctx := Context{
 		AppID:        flags.AppID,
 		CacheEnabled: !flags.NoCache,
@@ -80,6 +81,10 @@ func makeDefaultContext(flags *CommonFlags) (Context, error) {
 		StripDebug:   !flags.NoStripDebug,
 		Debug:        flags.Debug,
 		Volume:       vol,
+	}
+
+	if len(flags.Ldflags) > 0 {
+		ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
 	}
 
 	if flags.Silent {

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -1,0 +1,66 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_makeDefaultContext(t *testing.T) {
+	type args struct {
+		flags *CommonFlags
+	}
+	tests := []struct {
+		name        string
+		args        args
+		wantEnv     []string
+		wantLdFlags []string
+	}{
+		{
+			name: "default",
+			args: args{
+				flags: &CommonFlags{
+					Env: &envFlag{},
+				},
+			},
+			wantEnv:     []string{},
+			wantLdFlags: nil,
+		},
+		{
+			name: "custom env",
+			args: args{
+				flags: &CommonFlags{
+					Env: &envFlag{"TEST=true"},
+				},
+			},
+			wantEnv:     []string{"TEST=true"},
+			wantLdFlags: nil,
+		},
+		{
+			name: "custom ldflags",
+			args: args{
+				flags: &CommonFlags{
+					Env:     &envFlag{},
+					Ldflags: "-X main.version=1.2.3",
+				},
+			},
+			wantEnv:     []string{},
+			wantLdFlags: []string{"-X main.version=1.2.3"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, err := makeDefaultContext(tt.args.flags)
+			if err != nil {
+				t.Errorf("couldn't create Windows context: %v", err)
+			}
+
+			if !reflect.DeepEqual(ctx.Env, tt.wantEnv) {
+				t.Errorf("expected env %s but got %s", tt.wantEnv, ctx.Env)
+			}
+
+			if !reflect.DeepEqual(ctx.LdFlags, tt.wantLdFlags) {
+				t.Errorf("expected ldflags %s but got %s", tt.wantLdFlags, ctx.LdFlags)
+			}
+		})
+	}
+}

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -186,6 +186,11 @@ func darwinContext(flags *darwinFlags) ([]Context, error) {
 			ctx.Env = append(ctx.Env, "GOOS=darwin", "GOARCH=386", "CC=o32-clang")
 		}
 
+		// set context based on command-line flags
+		if len(flags.Ldflags) > 0 {
+			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+		}
+
 		if flags.DockerImage == "" {
 			ctx.DockerImage = darwinImage
 		}

--- a/internal/command/darwin.go
+++ b/internal/command/darwin.go
@@ -187,10 +187,6 @@ func darwinContext(flags *darwinFlags) ([]Context, error) {
 		}
 
 		// set context based on command-line flags
-		if len(flags.Ldflags) > 0 {
-			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-		}
-
 		if flags.DockerImage == "" {
 			ctx.DockerImage = darwinImage
 		}

--- a/internal/command/freebsd.go
+++ b/internal/command/freebsd.go
@@ -153,6 +153,11 @@ func freebsdContext(flags *freebsdFlags) ([]Context, error) {
 			ctx.Env = append(ctx.Env, "GOOS=freebsd", "GOARCH=amd64", "CC=x86_64-unknown-freebsd11-clang")
 		}
 
+		// set context based on command-line flags
+		if len(flags.Ldflags) > 0 {
+			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+		}
+
 		if flags.DockerImage == "" {
 			ctx.DockerImage = defaultDockerImage
 		}

--- a/internal/command/freebsd.go
+++ b/internal/command/freebsd.go
@@ -154,10 +154,6 @@ func freebsdContext(flags *freebsdFlags) ([]Context, error) {
 		}
 
 		// set context based on command-line flags
-		if len(flags.Ldflags) > 0 {
-			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-		}
-
 		if flags.DockerImage == "" {
 			ctx.DockerImage = defaultDockerImage
 		}

--- a/internal/command/ios.go
+++ b/internal/command/ios.go
@@ -200,10 +200,6 @@ func makeIOSContext(flags *iosFlags) (Context, error) {
 	ctx.ID = iosOS
 
 	// set context based on command-line flags
-	if len(flags.Ldflags) > 0 {
-		ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-	}
-
 	if flags.DockerImage == "" {
 		ctx.DockerImage = iosImage
 	}

--- a/internal/command/ios.go
+++ b/internal/command/ios.go
@@ -199,6 +199,11 @@ func makeIOSContext(flags *iosFlags) (Context, error) {
 	ctx.OS = iosOS
 	ctx.ID = iosOS
 
+	// set context based on command-line flags
+	if len(flags.Ldflags) > 0 {
+		ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+	}
+
 	if flags.DockerImage == "" {
 		ctx.DockerImage = iosImage
 	}

--- a/internal/command/linux.go
+++ b/internal/command/linux.go
@@ -198,10 +198,6 @@ func linuxContext(flags *linuxFlags) ([]Context, error) {
 		}
 
 		// set context based on command-line flags
-		if len(flags.Ldflags) > 0 {
-			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-		}
-
 		if flags.DockerImage == "" {
 			ctx.DockerImage = defaultDockerImage
 		}

--- a/internal/command/linux.go
+++ b/internal/command/linux.go
@@ -197,6 +197,11 @@ func linuxContext(flags *linuxFlags) ([]Context, error) {
 			ctx.Tags = []string{"gles"}
 		}
 
+		// set context based on command-line flags
+		if len(flags.Ldflags) > 0 {
+			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+		}
+
 		if flags.DockerImage == "" {
 			ctx.DockerImage = defaultDockerImage
 		}

--- a/internal/command/windows.go
+++ b/internal/command/windows.go
@@ -191,11 +191,13 @@ func makeWindowsContext(flags *windowsFlags) ([]Context, error) {
 			ctx.Env = append(ctx.Env, "GOOS=windows", "GOARCH=386", "CC=i686-w64-mingw32-gcc")
 		}
 
-		ctx.LdFlags = []string{"-H windowsgui"}
-
 		// set context based on command-line flags
-		if flags.Console {
-			ctx.LdFlags = []string{}
+		if len(flags.Ldflags) > 0 {
+			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
+		}
+
+		if !flags.Console {
+			ctx.LdFlags = append(ctx.LdFlags, "-H windowsgui")
 		}
 
 		if flags.DockerImage == "" {

--- a/internal/command/windows.go
+++ b/internal/command/windows.go
@@ -191,11 +191,6 @@ func makeWindowsContext(flags *windowsFlags) ([]Context, error) {
 			ctx.Env = append(ctx.Env, "GOOS=windows", "GOARCH=386", "CC=i686-w64-mingw32-gcc")
 		}
 
-		// set context based on command-line flags
-		if len(flags.Ldflags) > 0 {
-			ctx.LdFlags = append(ctx.LdFlags, flags.Ldflags)
-		}
-
 		if !flags.Console {
 			ctx.LdFlags = append(ctx.LdFlags, "-H windowsgui")
 		}

--- a/internal/command/windows_test.go
+++ b/internal/command/windows_test.go
@@ -1,0 +1,118 @@
+package command
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func Test_makeWindowsContext(t *testing.T) {
+	type args struct {
+		flags *windowsFlags
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantEnv         []string
+		wantLdFlags     []string
+		wantDockerImage string
+	}{
+		{
+			name: "default",
+			args: args{
+				flags: &windowsFlags{
+					CommonFlags: &CommonFlags{
+						Env: &envFlag{},
+					},
+					TargetArch: &targetArchFlag{"amd64"},
+				},
+			},
+			wantEnv:         []string{"GOOS=windows", "GOARCH=amd64", "CC=x86_64-w64-mingw32-gcc"},
+			wantLdFlags:     []string{"-H windowsgui"},
+			wantDockerImage: "lucor/fyne-cross:base-latest",
+		},
+		{
+			name: "console",
+			args: args{
+				flags: &windowsFlags{
+					CommonFlags: &CommonFlags{
+						Env: &envFlag{},
+					},
+					TargetArch: &targetArchFlag{"386"},
+					Console:    true,
+				},
+			},
+			wantEnv:         []string{"GOOS=windows", "GOARCH=386", "CC=i686-w64-mingw32-gcc"},
+			wantLdFlags:     nil,
+			wantDockerImage: "lucor/fyne-cross:base-latest",
+		},
+		{
+			name: "custom ldflags",
+			args: args{
+				flags: &windowsFlags{
+					CommonFlags: &CommonFlags{
+						Env:     &envFlag{},
+						Ldflags: "-X main.version=1.2.3",
+					},
+					TargetArch: &targetArchFlag{"amd64"},
+				},
+			},
+			wantEnv:         []string{"GOOS=windows", "GOARCH=amd64", "CC=x86_64-w64-mingw32-gcc"},
+			wantLdFlags:     []string{"-X main.version=1.2.3", "-H windowsgui"},
+			wantDockerImage: "lucor/fyne-cross:base-latest",
+		},
+		{
+			name: "custom docker image",
+			args: args{
+				flags: &windowsFlags{
+					CommonFlags: &CommonFlags{
+						Env:         &envFlag{},
+						DockerImage: "test",
+					},
+					TargetArch: &targetArchFlag{"amd64"},
+				},
+			},
+			wantEnv:         []string{"GOOS=windows", "GOARCH=amd64", "CC=x86_64-w64-mingw32-gcc"},
+			wantLdFlags:     []string{"-H windowsgui"},
+			wantDockerImage: "test",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetArch := []string(*tt.args.flags.TargetArch)[0]
+			ctx, err := makeWindowsContext(tt.args.flags)
+			if err != nil {
+				t.Errorf("couldn't create Windows context: %v", err)
+			}
+
+			if len(ctx) != 1 {
+				t.Errorf("len of context should be 1, but got %d", len(ctx))
+			}
+
+			if ctx[0].Architecture != Architecture(targetArch) {
+				t.Errorf("architecture should be %s, but got %s", tt.args.flags.TargetArch, ctx[0].Architecture)
+			}
+
+			if ctx[0].OS != windowsOS {
+				t.Errorf("architecture should be %s, but got %s", windowsOS, ctx[0].OS)
+			}
+
+			wantID := fmt.Sprintf("%s-%s", windowsOS, targetArch)
+			if ctx[0].ID != wantID {
+				t.Errorf("ID should be %s, but got %s", wantID, ctx[0].ID)
+			}
+
+			if !reflect.DeepEqual(ctx[0].Env, tt.wantEnv) {
+				t.Errorf("expected env %s but got %s", tt.wantEnv, ctx[0].Env)
+			}
+
+			if !reflect.DeepEqual(ctx[0].LdFlags, tt.wantLdFlags) {
+				t.Errorf("expected ldflags %s but got %s", tt.wantLdFlags, ctx[0].LdFlags)
+			}
+
+			if ctx[0].DockerImage != tt.wantDockerImage {
+				t.Errorf("docker image should be %s, but got %s", tt.wantDockerImage, ctx[0].DockerImage)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #62 

`flags.Ldflags` was not passed to the context of each command.

Now, with no ldflags, building on Linux, only `-s -w` is set:

```
$ fyne-cross linux -debug
[i] Target: linux/amd64
command.Context{Volume:volume.Volume{binDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/bin", cacheDirHost:"/home/alexis/.cache/fyne-cross", distDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/dist", tmpDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/tmp", workDirHost:"/home/alexis/fyne-cross-ldflags"}, Architecture:"amd64", Env:[]string{"GOOS=linux", "GOARCH=amd64", "CC=gcc"}, ID:"linux-amd64", LdFlags:[]string(nil), OS:"linux", Tags:[]string(nil), AppID:"fyne-cross-ldflags", CacheEnabled:true, DockerImage:"lucor/fyne-cross:base-latest", Icon:"/home/alexis/fyne-cross-ldflags/Icon.png", Output:"fyne-cross-ldflags", Package:".", StripDebug:true, Debug:true}
[i] Cleaning target directories...
[✓] "bin" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/linux-amd64
[✓] "dist" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/linux-amd64
[✓] "temp" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/tmp/linux-amd64
[i] Checking for go.mod: /home/alexis/fyne-cross-ldflags/go.mod
[✓] go.mod found
[i] Building binary...
/usr/bin/docker run --rm -t -w /app -v /home/alexis/fyne-cross-ldflags:/app -v /home/alexis/.cache/fyne-cross:/go -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOOS=linux -e GOARCH=amd64 -e CC=gcc -e fyne_uid=1000 lucor/fyne-cross:base-latest go build -ldflags '-w -s' -o /app/fyne-cross/bin/linux-amd64/fyne-cross-ldflags -v .
[✓] Binary: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/linux-amd64/fyne-cross-ldflags
[i] Packaging app...
/usr/bin/docker run --rm -t -w /app/fyne-cross/tmp/linux-amd64 -v /home/alexis/fyne-cross-ldflags:/app -v /home/alexis/.cache/fyne-cross:/go -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e fyne_uid=1000 lucor/fyne-cross:base-latest /usr/local/bin/fyne package -os linux -name fyne-cross-ldflags -icon /app/fyne-cross/tmp/linux-amd64/Icon.png -appID fyne-cross-ldflags -executable /app/fyne-cross/bin/linux-amd64/fyne-cross-ldflags
[✓] Package: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/linux-amd64/fyne-cross-ldflags.tar.gz
```

When set, the ldflags are passed along `-s -w`:

```
$ fyne-cross linux -debug -ldflags "-X main.version=1.2.3"
[i] Target: linux/amd64
command.Context{Volume:volume.Volume{binDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/bin", cacheDirHost:"/home/alexis/.cache/fyne-cross", distDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/dist", tmpDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/tmp", workDirHost:"/home/alexis/fyne-cross-ldflags"}, Architecture:"amd64", Env:[]string{"GOOS=linux", "GOARCH=amd64", "CC=gcc"}, ID:"linux-amd64", LdFlags:[]string{"-X main.version=1.2.3"}, OS:"linux", Tags:[]string(nil), AppID:"fyne-cross-ldflags", CacheEnabled:true, DockerImage:"lucor/fyne-cross:base-latest", Icon:"/home/alexis/fyne-cross-ldflags/Icon.png", Output:"fyne-cross-ldflags", Package:".", StripDebug:true, Debug:true}
[i] Cleaning target directories...
[✓] "bin" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/linux-amd64
[✓] "dist" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/linux-amd64
[✓] "temp" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/tmp/linux-amd64
[i] Checking for go.mod: /home/alexis/fyne-cross-ldflags/go.mod
[✓] go.mod found
[i] Building binary...
/usr/bin/docker run --rm -t -w /app -v /home/alexis/fyne-cross-ldflags:/app -v /home/alexis/.cache/fyne-cross:/go -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOOS=linux -e GOARCH=amd64 -e CC=gcc -e fyne_uid=1000 lucor/fyne-cross:base-latest go build -ldflags '-X main.version=1.2.3 -w -s' -o /app/fyne-cross/bin/linux-amd64/fyne-cross-ldflags -v .
[✓] Binary: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/linux-amd64/fyne-cross-ldflags
[i] Packaging app...
/usr/bin/docker run --rm -t -w /app/fyne-cross/tmp/linux-amd64 -v /home/alexis/fyne-cross-ldflags:/app -v /home/alexis/.cache/fyne-cross:/go -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e fyne_uid=1000 lucor/fyne-cross:base-latest /usr/local/bin/fyne package -os linux -name fyne-cross-ldflags -icon /app/fyne-cross/tmp/linux-amd64/Icon.png -appID fyne-cross-ldflags -executable /app/fyne-cross/bin/linux-amd64/fyne-cross-ldflags
[✓] Package: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/linux-amd64/fyne-cross-ldflags.tar.gz
```

On Windows, `-H windowsgui` is also passed if `-no-strip-debug` is not set:

```
$ fyne-cross windows -debug -ldflags "-X main.version=1.2.3"
[i] Target: windows/amd64
command.Context{Volume:volume.Volume{binDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/bin", cacheDirHost:"/home/alexis/.cache/fyne-cross", distDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/dist", tmpDirHost:"/home/alexis/fyne-cross-ldflags/fyne-cross/tmp", workDirHost:"/home/alexis/fyne-cross-ldflags"}, Architecture:"amd64", Env:[]string{"GOOS=windows", "GOARCH=amd64", "CC=x86_64-w64-mingw32-gcc"}, ID:"windows-amd64", LdFlags:[]string{"-X main.version=1.2.3", "-H windowsgui"}, OS:"windows", Tags:[]string(nil), AppID:"fyne-cross-ldflags", CacheEnabled:true, DockerImage:"lucor/fyne-cross:base-latest", Icon:"/home/alexis/fyne-cross-ldflags/Icon.png", Output:"fyne-cross-ldflags.exe", Package:".", StripDebug:true, Debug:true}
[i] Cleaning target directories...
[✓] "dist" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/windows-amd64
[✓] "temp" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/tmp/windows-amd64
[✓] "bin" dir cleaned: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/windows-amd64
[i] Checking for go.mod: /home/alexis/fyne-cross-ldflags/go.mod
[✓] go.mod found
/usr/bin/docker run --rm -t -w /app/fyne-cross/tmp/windows-amd64 -v /home/alexis/fyne-cross-ldflags:/app -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e fyne_uid=1000 lucor/fyne-cross:base-latest /usr/local/bin/gowindres -arch amd64 -output fyne-cross-ldflags.exe -workdir /app/fyne-cross/tmp/windows-amd64
[i] Building binary...
/usr/bin/docker run --rm -t -w /app -v /home/alexis/fyne-cross-ldflags:/app -v /home/alexis/.cache/fyne-cross:/go -e CGO_ENABLED=1 -e GOCACHE=/go/go-build -e GOOS=windows -e GOARCH=amd64 -e CC=x86_64-w64-mingw32-gcc -e fyne_uid=1000 lucor/fyne-cross:base-latest go build -ldflags '-X main.version=1.2.3 -H windowsgui -w -s' -o /app/fyne-cross/bin/windows-amd64/fyne-cross-ldflags.exe -v .
[✓] Binary: /home/alexis/fyne-cross-ldflags/fyne-cross/bin/windows-amd64/fyne-cross-ldflags.exe
[i] Packaging app...
[✓] Package: /home/alexis/fyne-cross-ldflags/fyne-cross/dist/windows-amd64/fyne-cross-ldflags.exe.zip
```