### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [2.1.0] - Unreleased
+- Add support for build flags #69
+
 ## [2.0.0] - 2020-06-07
 - Base image is based on dockercore/golang-cross@1.13.12 (Go v1.13.12)
 - fyne cli updated to v1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.0] - Unreleased
+## [2.1.0] - 2020-07-16
 - Add support for build flags #69
 - Base image is based on dockercore/golang-cross@1.13.13 (Go v1.13.13)
 - fyne cli updated to v1.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.1.0] - Unreleased
 - Add support for build flags #69
+- Base image is based on dockercore/golang-cross@1.13.13 (Go v1.13.13)
 - fyne cli updated to v1.3.2
 
 ## [2.0.0] - 2020-06-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.1.0] - Unreleased
 - Add support for build flags #69
+- fyne cli updated to v1.3.2
 
 ## [2.0.0] - 2020-06-07
 - Base image is based on dockercore/golang-cross@1.13.12 (Go v1.13.12)

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.07.16
+- Base image is based on dockercore/golang-cross@1.13.13 (Go v1.13.13)
+- fyne cli updated to v1.3.2
+
 # Release 20.06.07
 - Base image is based on dockercore/golang-cross@1.13.12 (Go v1.13.12)
 - fyne cli updated to v1.3.0

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
 # docker cross 1.13.12
 ARG DOCKER_CROSS_VERSION=sha256:ad1b962c4db7a04d7bad5e676589c58c9532feecdb24eccaa8090de878e4c891
 # fyne stable branch
-ARG FYNE_VERSION=v1.3.0
+ARG FYNE_VERSION=v1.3.2
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,5 +1,5 @@
-# docker cross 1.13.12
-ARG DOCKER_CROSS_VERSION=sha256:ad1b962c4db7a04d7bad5e676589c58c9532feecdb24eccaa8090de878e4c891
+# docker cross 1.13.13
+ARG DOCKER_CROSS_VERSION=sha256:4a1f78f11f5d9e15ea1400c4c9901c5c396e3ec3fb202fb12ec32d5d461125ad
 # fyne stable branch
 ARG FYNE_VERSION=v1.3.2
 

--- a/internal/command/context.go
+++ b/internal/command/context.go
@@ -78,6 +78,7 @@ func makeDefaultContext(flags *CommonFlags, args []string) (Context, error) {
 		CacheEnabled: !flags.NoCache,
 		DockerImage:  flags.DockerImage,
 		Env:          flags.Env,
+		Tags:         flags.Tags,
 		Icon:         flags.Icon,
 		Output:       flags.Output,
 		StripDebug:   !flags.NoStripDebug,

--- a/internal/command/context_test.go
+++ b/internal/command/context_test.go
@@ -132,6 +132,22 @@ func Test_makeDefaultContext(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "custom tags",
+			args: args{
+				flags: &CommonFlags{
+					Tags: tagsFlag{"hints", "gles"},
+				},
+			},
+			want: Context{
+				Volume:       vol,
+				CacheEnabled: true,
+				StripDebug:   true,
+				Package:      ".",
+				Tags:         []string{"hints", "gles"},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/command/docker.go
+++ b/internal/command/docker.go
@@ -142,7 +142,7 @@ func goBuild(ctx Context) error {
 	// add tags to command, if any
 	tags := ctx.Tags
 	if len(tags) > 0 {
-		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, " ")))
+		args = append(args, "-tags", fmt.Sprintf("'%s'", strings.Join(tags, ",")))
 	}
 
 	// set output folder to fyne-cross/bin/<target>

--- a/internal/command/flag.go
+++ b/internal/command/flag.go
@@ -28,6 +28,8 @@ type CommonFlags struct {
 	Icon string
 	// Ldflags represents the flags to pass to the external linker
 	Ldflags string
+	// Additional build tags
+	Tags tagsFlag
 	// NoCache if true will not use the go build cache
 	NoCache bool
 	// NoStripDebug if true will not strip debug information from binaries
@@ -70,6 +72,7 @@ func newCommonFlags() (*CommonFlags, error) {
 	flagSet.StringVar(&flags.Icon, "icon", defaultIcon, "Application icon used for distribution")
 	flagSet.StringVar(&flags.DockerImage, "image", "", "Custom docker image to use for build")
 	flagSet.StringVar(&flags.Ldflags, "ldflags", "", "Additional flags to pass to the external linker")
+	flagSet.Var(&flags.Tags, "tags", "List of additional build tags separated by comma")
 	flagSet.BoolVar(&flags.NoStripDebug, "no-strip-debug", false, "Do not strip debug information from binaries")
 	flagSet.StringVar(&flags.Output, "output", output, "Named output file")
 	flagSet.StringVar(&flags.RootDir, "dir", rootDir, "Fyne app root directory")
@@ -140,7 +143,31 @@ func (af *targetArchFlag) Set(value string) error {
 	}
 
 	for _, v := range strings.Split(value, ",") {
-		*af = append(*af, v)
+		*af = append(*af, strings.TrimSpace(v))
+	}
+	return nil
+}
+
+// tagsFlag is a custom flag used to define build tags
+type tagsFlag []string
+
+// String is the method to format the flag's value, part of the flag.Value interface.
+// The String method's output will be used in diagnostics.
+func (tf *tagsFlag) String() string {
+	return fmt.Sprint(*tf)
+}
+
+// Set is the method to set the flag value, part of the flag.Value interface.
+// Set's argument is a string to be parsed to set the flag.
+// It's a comma-separated list, so we split it.
+func (tf *tagsFlag) Set(value string) error {
+	*tf = []string{}
+	if len(*tf) > 1 {
+		return errors.New("flag already set")
+	}
+
+	for _, v := range strings.Split(value, ",") {
+		*tf = append(*tf, strings.TrimSpace(v))
 	}
 	return nil
 }

--- a/internal/command/linux.go
+++ b/internal/command/linux.go
@@ -190,11 +190,11 @@ func linuxContext(flags *linuxFlags, args []string) ([]Context, error) {
 		case ArchArm:
 			defaultDockerImage = linuxImageArm
 			ctx.Env = append(ctx.Env, "GOOS=linux", "GOARCH=arm", "CC=arm-linux-gnueabihf-gcc", "GOARM=7")
-			ctx.Tags = []string{"gles"}
+			ctx.Tags = append(ctx.Tags, "gles")
 		case ArchArm64:
 			defaultDockerImage = linuxImageArm64
 			ctx.Env = append(ctx.Env, "GOOS=linux", "GOARCH=arm64", "CC=aarch64-linux-gnu-gcc")
-			ctx.Tags = []string{"gles"}
+			ctx.Tags = append(ctx.Tags, "gles")
 		}
 
 		// set context based on command-line flags


### PR DESCRIPTION
- Add support for build flags #69
- Base image is based on dockercore/golang-cross@1.13.13 (Go v1.13.13)
- fyne cli updated to v1.3.2