### PR TITLE
Release 2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.2] - 2020-08-13
+- Update base image to dockercore/golang-cross@1.13.15 (Go v1.13.15)
+- fyne cli updated to v1.3.3
+
 ## [2.1.1] - 2020-07-17
 - Update base image to dockercore/golang-cross@1.13.14 (Go v1.13.14)
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the fyne-cross docker images will be documented in this f
 Release cycle won't follow the fyne-cross one, so the images will be tagged using the label
 year.month.day along with the latest one.
 
+# Release 20.08.13
+- Base image is based on dockercore/golang-cross@1.13.15 (Go v1.13.15)
+- fyne cli updated to v1.3.3
+
 # Release 20.07.17
 - Base image is based on dockercore/golang-cross@1.13.14 (Go v1.13.14)
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,7 +1,7 @@
-# docker cross 1.13.14
-ARG DOCKER_CROSS_VERSION=sha256:b061752ed954a3da73834aa93e735f5882b2ac4220f1166f2da1467121acb288
+# docker cross 1.13.15
+ARG DOCKER_CROSS_VERSION=sha256:11a04661d910f74c419623ef7880024694f9151c17578af15e86c45cdf6c8588
 # fyne stable branch
-ARG FYNE_VERSION=v1.3.2
+ARG FYNE_VERSION=v1.3.3
 
 # Build the fyne command utility
 FROM dockercore/golang-cross@${DOCKER_CROSS_VERSION} AS fyne


### PR DESCRIPTION
- Base image is based on dockercore/golang-cross@1.13.15 (Go v1.13.15)
- fyne cli updated to v1.3.3