### PR TITLE
Release 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [2.2.1] - 2020-09-16
 - Fix iOS fails with "only on darwin" when on mac #78
 - Update README installation when module-aware mode is not enabled
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 - Fix iOS fails with "only on darwin" when on mac #78
+- Update README installation when module-aware mode is not enabled
 
 ## [2.2.0] - 2020-09-01
 - Add `--pull` option to attempt to pull a newer version of the docker image #75

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix iOS fails with "only on darwin" when on mac #78
+
 ## [2.2.0] - 2020-09-01
 - Add `--pull` option to attempt to pull a newer version of the docker image #75
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ Supported targets are:
 
 - go >= 1.13
 - docker
+- [module-aware mode](https://golang.org/ref/mod#mod-commands) enabled
 
 ### Installation
 
 ```
-go get github.com/lucor/fyne-cross/v2/cmd/fyne-cross
+GO111MODULE=on go get github.com/lucor/fyne-cross/v2/cmd/fyne-cross
 ```
+
+> `fyne-cross` will be installed in GOPATH/bin, unless GOBIN is set.
 
 ### Updating docker images
 

--- a/internal/command/ios.go
+++ b/internal/command/ios.go
@@ -190,7 +190,7 @@ type iosFlags struct {
 // makeIOSContext returns the command context for an iOS target
 func makeIOSContext(flags *iosFlags, args []string) (Context, error) {
 
-	if runtime.GOOS == darwinOS {
+	if runtime.GOOS != darwinOS {
 		return Context{}, fmt.Errorf("iOS build is supported only on darwin hosts")
 	}
 


### PR DESCRIPTION
- Fix iOS fails with "only on darwin" when on mac #78
- Update README installation when module-aware mode is not enabled